### PR TITLE
fix literal underscore encoding

### DIFF
--- a/q.js
+++ b/q.js
@@ -34,7 +34,7 @@
 			});
 	};
 
-	var regexUnsafeSymbols = /[\0-\x1F"-\),\.:-@\[-\^`\{-\uFFFF]/g;
+	var regexUnsafeSymbols = /[\0-\x1F"-\),\.:-@\[-_`\{-\uFFFF]/g;
 	var encode = function(string) {
 		// Note: this assumes the input is already encoded into octets (e.g. using
 		// UTF-8), and that the resulting octets are within the extended ASCII

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -86,6 +86,11 @@
 			'ooh=3A_ahh',
 			'colons'
 		);
+		equal(
+			q.encode('my dog_has fleas'),
+			'my_dog=5Fhas_fleas',
+			'underscore roundtrip, disambiguate from original space'
+		)
 		raises(
 			function() {
 				// Note: “forgot” to UTF-8-encode first


### PR DESCRIPTION
Literal underscore needs to be encoded as `=5F` or else the encoded product is ambiguous. #4 